### PR TITLE
Wii U: Use VPad/KPad instead of SDL input

### DIFF
--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -44,7 +44,9 @@ unsigned int configKeyStickUp    = 0x11;
 unsigned int configKeyStickDown  = 0x1F;
 unsigned int configKeyStickLeft  = 0x1E;
 unsigned int configKeyStickRight = 0x20;
-
+#ifdef TARGET_WII_U
+bool configN64FaceButtons = 1;
+#endif
 
 static const struct ConfigOption options[] = {
     {.name = "fullscreen",     .type = CONFIG_TYPE_BOOL, .boolValue = &configFullscreen},
@@ -61,6 +63,9 @@ static const struct ConfigOption options[] = {
     {.name = "key_stickdown",  .type = CONFIG_TYPE_UINT, .uintValue = &configKeyStickDown},
     {.name = "key_stickleft",  .type = CONFIG_TYPE_UINT, .uintValue = &configKeyStickLeft},
     {.name = "key_stickright", .type = CONFIG_TYPE_UINT, .uintValue = &configKeyStickRight},
+#ifdef TARGET_WII_U
+    {.name = "n64_face_buttons", .type = CONFIG_TYPE_BOOL, .boolValue = &configN64FaceButtons}
+#endif
 };
 
 // Reads an entire line from a file (excluding the newline character) and returns an allocated string

--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -45,7 +45,7 @@ unsigned int configKeyStickDown  = 0x1F;
 unsigned int configKeyStickLeft  = 0x1E;
 unsigned int configKeyStickRight = 0x20;
 #ifdef TARGET_WII_U
-bool configN64FaceButtons = 1;
+bool configN64FaceButtons = 0;
 #endif
 
 static const struct ConfigOption options[] = {

--- a/src/pc/configfile.h
+++ b/src/pc/configfile.h
@@ -15,6 +15,9 @@ extern unsigned int configKeyStickUp;
 extern unsigned int configKeyStickDown;
 extern unsigned int configKeyStickLeft;
 extern unsigned int configKeyStickRight;
+#ifdef TARGET_WII_U
+extern bool configN64FaceButtons;
+#endif
 
 void configfile_load(const char *filename);
 void configfile_save(const char *filename);

--- a/src/pc/controller/controller_entry_point.c
+++ b/src/pc/controller/controller_entry_point.c
@@ -30,9 +30,7 @@ static struct ControllerAPI *controller_implementations[] = {
 #ifdef __linux__
     &controller_wup,
 #endif
-#ifndef __WIIU__
     &controller_keyboard,
-#endif
 };
 
 s32 osContInit(UNUSED OSMesgQueue *mq, u8 *controllerBits, UNUSED OSContStatus *status) {

--- a/src/pc/controller/controller_entry_point.c
+++ b/src/pc/controller/controller_entry_point.c
@@ -8,6 +8,8 @@
 
 #if defined(_WIN32) || defined(_WIN64)
 #include "controller_xinput.h"
+#elif defined(TARGET_WII_U)
+#include "controller_wiiu.h"
 #else
 #include "controller_sdl.h"
 #endif
@@ -20,6 +22,8 @@ static struct ControllerAPI *controller_implementations[] = {
     &controller_recorded_tas,
 #if defined(_WIN32) || defined(_WIN64)
     &controller_xinput,
+#elif defined(__WIIU__)
+    &controller_wiiu,
 #else
     &controller_sdl,
 #endif

--- a/src/pc/controller/controller_keyboard.c
+++ b/src/pc/controller/controller_keyboard.c
@@ -1,5 +1,3 @@
-#ifndef __WIIU__
-
 #include <stdbool.h>
 #include <ultra64.h>
 
@@ -88,5 +86,3 @@ struct ControllerAPI controller_keyboard = {
     keyboard_init,
     keyboard_read
 };
-
-#endif

--- a/src/pc/controller/controller_sdl.c
+++ b/src/pc/controller/controller_sdl.c
@@ -1,4 +1,4 @@
-#if !defined(_WIN32) && !defined(_WIN64)
+#if !defined(_WIN32) && !defined(_WIN64) && !defined(TARGET_WII_U)
 
 #include <stdio.h>
 #include <stdint.h>

--- a/src/pc/controller/controller_wiiu.c
+++ b/src/pc/controller/controller_wiiu.c
@@ -66,6 +66,10 @@ static void read_vpad(OSContPad *pad) {
     uint32_t v;
 
     VPADRead(VPAD_CHAN_0, &status, 1, &err);
+
+    if (err != 0)
+        return;
+
     v = status.hold;
 
     for (int i = 0; i < num_buttons; i++) {

--- a/src/pc/controller/controller_wiiu.c
+++ b/src/pc/controller/controller_wiiu.c
@@ -39,8 +39,8 @@ typedef struct Vec2D {
 #define SE(dir) VPAD_STICK_R_EMULATION_##dir, WPAD_CLASSIC_STICK_R_EMULATION_##dir, WPAD_PRO_STICK_R_EMULATION_##dir
 
 struct WiiUKeymap map[] = {
-    { B_BUTTON, VB(B), CB(B), PB(B) },
-    { A_BUTTON, VB(A), CB(A), PB(A) },
+    { B_BUTTON, VB(B) | VB(Y), CB(B) | CB(Y), PB(B) | PB(Y) },
+    { A_BUTTON, VB(A) | VB(X), CB(A) | CB(X), PB(A) | PB(X) },
     { START_BUTTON, VB(PLUS), CB(PLUS), PB(PLUS) },
     { Z_TRIG, VB(L) | VB(ZL), CB(L) | CB(ZL), PT(L) | PT(ZL) },
     { R_TRIG, VB(R) | VB(ZR), CB(R) | CB(ZR), PT(R) | PT(ZR) },

--- a/src/pc/controller/controller_wiiu.c
+++ b/src/pc/controller/controller_wiiu.c
@@ -39,8 +39,8 @@ typedef struct Vec2D {
 #define SE(dir) VPAD_STICK_R_EMULATION_##dir, WPAD_CLASSIC_STICK_R_EMULATION_##dir, WPAD_PRO_STICK_R_EMULATION_##dir
 
 struct WiiUKeymap map[] = {
-    { B_BUTTON, VB(X) | VB(A), CB(X) | CB(A), PB(X) | PB(A) },
-    { A_BUTTON, VB(Y) | VB(B), CB(Y) | CB(B), PB(Y) | PB(B) },
+    { B_BUTTON, VB(B), CB(B), PB(B) },
+    { A_BUTTON, VB(A), CB(A), PB(A) },
     { START_BUTTON, VB(PLUS), CB(PLUS), PB(PLUS) },
     { Z_TRIG, VB(L) | VB(ZL), CB(L) | CB(ZL), PT(L) | PT(ZL) },
     { R_TRIG, VB(R) | VB(ZR), CB(R) | CB(ZR), PT(R) | PT(ZR) },
@@ -58,10 +58,8 @@ static void controller_wiiu_init(void) {
     WPADEnableWiiRemote(1);
 
     if (configN64FaceButtons) {
-        struct WiiUKeymap b = { B_BUTTON, VB(Y) | VB(X), CB(Y) | CB(X), PB(Y) | PB(X) };
-        struct WiiUKeymap a = { A_BUTTON, VB(B) | VB(A), CB(B) | CB(A), PB(B) | PB(A) };
-        map[0] = b;
-        map[1] = a;
+        map[0] = (struct WiiUKeymap) { B_BUTTON, VB(Y) | VB(X), CB(Y) | CB(X), PB(Y) | PB(X) };
+        map[1] = (struct WiiUKeymap) { A_BUTTON, VB(B) | VB(A), CB(B) | CB(A), PB(B) | PB(A) };
     }
 }
 

--- a/src/pc/controller/controller_wiiu.c
+++ b/src/pc/controller/controller_wiiu.c
@@ -1,0 +1,134 @@
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <ultra64.h>
+
+#include <vpad/input.h>
+#include <padscore/wpad.h>
+#include <padscore/kpad.h>
+
+#include "controller_api.h"
+
+static void controller_wiiu_init(void) {
+    VPADInit();
+    KPADInit();
+    WPADEnableURCC(1);
+    WPADEnableWiiRemote(1);
+}
+
+static void read_vpad(OSContPad *pad) {
+    VPADStatus status;
+    VPADReadError err;
+    uint32_t v;
+
+    VPADRead(VPAD_CHAN_0, &status, 1, &err);
+    v = status.hold;
+
+    if (v & VPAD_BUTTON_B || v & VPAD_BUTTON_A) pad->button |= A_BUTTON;
+    if (v & VPAD_BUTTON_Y || v & VPAD_BUTTON_X) pad->button |= B_BUTTON;
+    if (v & VPAD_BUTTON_ZL || v & VPAD_BUTTON_L) pad->button |= Z_TRIG;
+    if (v & VPAD_BUTTON_R || v & VPAD_BUTTON_ZR) pad->button |= R_TRIG;
+    if (v & VPAD_BUTTON_PLUS) pad->button |= START_BUTTON;
+    if (v & VPAD_STICK_R_EMULATION_UP) pad->button |= U_CBUTTONS;
+    if (v & VPAD_STICK_R_EMULATION_RIGHT) pad->button |= R_CBUTTONS;
+    if (v & VPAD_STICK_R_EMULATION_DOWN) pad->button |= D_CBUTTONS;
+    if (v & VPAD_STICK_R_EMULATION_LEFT) pad->button |= L_CBUTTONS;
+
+    if (status.leftStick.x < 0)
+        pad->stick_x = (s8) (status.leftStick.x * 128);
+    else
+        pad->stick_x = (s8) (status.leftStick.x * 127);
+
+    if (status.leftStick.y < 0)
+        pad->stick_y = (s8) (status.leftStick.y * 128);
+    else
+        pad->stick_y = (s8) (status.leftStick.y * 127);
+
+}
+
+static void read_wpad(OSContPad* pad) {
+    // Disconnect any extra controllers
+    for (int i = 1; i < 4; i++) {
+        WPADExtensionType ext;
+        int res = WPADProbe(i, &ext);
+        if (res == 0) {
+            WPADDisconnect(i);
+        }
+    }
+
+    KPADStatus status;
+    int err;
+    int read = KPADReadEx(WPAD_CHAN_0, &status, 1, &err);
+    if (read == 0)
+        return;
+
+    uint32_t wm = status.hold;
+    KPADVec2D stick;
+    bool disconnect = false;
+    if (status.hold & WPAD_BUTTON_MINUS)
+        disconnect = true;
+
+    if (status.extensionType == WPAD_EXT_NUNCHUK || status.extensionType == WPAD_EXT_MPLUS_NUNCHUK) {
+        uint32_t ext = status.nunchuck.hold;
+        stick = status.nunchuck.stick;
+
+        if (wm & WPAD_BUTTON_A) pad->button |= A_BUTTON;
+        if (wm & WPAD_BUTTON_B) pad->button |= B_BUTTON;
+        if (wm & WPAD_BUTTON_PLUS) pad->button |= START_BUTTON;
+        if (wm & WPAD_BUTTON_UP) pad->button |= U_CBUTTONS;
+        if (wm & WPAD_BUTTON_DOWN) pad->button |= D_CBUTTONS;
+        if (wm & WPAD_BUTTON_LEFT) pad->button |= L_CBUTTONS;
+        if (wm & WPAD_BUTTON_RIGHT) pad->button |= R_CBUTTONS;
+        if (ext & WPAD_NUNCHUK_BUTTON_C) pad->button |= R_TRIG;
+        if (ext & WPAD_NUNCHUK_BUTTON_Z) pad->button |= Z_TRIG;
+    } else if (status.extensionType == WPAD_EXT_CLASSIC || status.extensionType == WPAD_EXT_MPLUS_CLASSIC) {
+        uint32_t ext = status.classic.hold;
+        stick = status.classic.leftStick;
+        if (ext & (WPAD_CLASSIC_BUTTON_B | WPAD_CLASSIC_BUTTON_A)) pad->button |= A_BUTTON;
+        if (ext & (WPAD_CLASSIC_BUTTON_Y | WPAD_CLASSIC_BUTTON_X)) pad->button |= B_BUTTON;
+        if (ext & (WPAD_CLASSIC_BUTTON_ZL | WPAD_CLASSIC_BUTTON_L)) pad->button |= Z_TRIG;
+        if (ext & (WPAD_CLASSIC_BUTTON_ZR | WPAD_CLASSIC_BUTTON_R)) pad->button |= R_TRIG;
+        if (ext & WPAD_CLASSIC_STICK_R_EMULATION_UP) pad->button |= U_CBUTTONS;
+        if (ext & WPAD_CLASSIC_STICK_R_EMULATION_DOWN) pad->button |= D_CBUTTONS;
+        if (ext & WPAD_CLASSIC_STICK_R_EMULATION_LEFT) pad->button |= L_CBUTTONS;
+        if (ext & WPAD_CLASSIC_STICK_R_EMULATION_RIGHT) pad->button |= R_CBUTTONS;
+        if (ext & WPAD_CLASSIC_BUTTON_PLUS) pad->button |= START_BUTTON;
+        if (ext & WPAD_CLASSIC_BUTTON_MINUS) disconnect = true;
+    } else if (status.extensionType == WPAD_EXT_PRO_CONTROLLER) {
+        uint32_t ext = status.pro.hold;
+        stick = status.pro.leftStick;
+        if (ext & (WPAD_PRO_BUTTON_B | WPAD_PRO_BUTTON_A)) pad->button |= A_BUTTON;
+        if (ext & (WPAD_PRO_BUTTON_Y | WPAD_PRO_BUTTON_X)) pad->button |= B_BUTTON;
+        if (ext & (WPAD_PRO_TRIGGER_ZL | WPAD_PRO_TRIGGER_L)) pad->button |= Z_TRIG;
+        if (ext & (WPAD_PRO_TRIGGER_ZR | WPAD_PRO_TRIGGER_R)) pad->button |= R_TRIG;
+        if (ext & WPAD_PRO_STICK_R_EMULATION_UP) pad->button |= U_CBUTTONS;
+        if (ext & WPAD_PRO_STICK_R_EMULATION_DOWN) pad->button |= D_CBUTTONS;
+        if (ext & WPAD_PRO_STICK_R_EMULATION_LEFT) pad->button |= L_CBUTTONS;
+        if (ext & WPAD_PRO_STICK_R_EMULATION_RIGHT) pad->button |= R_CBUTTONS;
+        if (ext & WPAD_PRO_BUTTON_PLUS) pad->button |= START_BUTTON;
+        if (ext & WPAD_PRO_BUTTON_MINUS) disconnect = true;
+    }
+
+    if (stick.x < 0)
+        pad->stick_x = (s8) (stick.x * 128);
+    else
+        pad->stick_x = (s8) (stick.x * 127);
+
+    if (stick.y < 0)
+        pad->stick_y = (s8) (stick.y * 128);
+    else
+        pad->stick_y = (s8) (stick.y * 127);
+
+    if (disconnect)
+        WPADDisconnect(WPAD_CHAN_0);
+}
+
+static void controller_wiiu_read(OSContPad* pad) {
+    read_vpad(pad);
+    read_wpad(pad);
+}
+
+struct ControllerAPI controller_wiiu = {
+    controller_wiiu_init,
+    controller_wiiu_read
+};

--- a/src/pc/controller/controller_wiiu.h
+++ b/src/pc/controller/controller_wiiu.h
@@ -1,0 +1,8 @@
+#ifndef CONTROLLER_WIIU_H
+#define CONTROLLER_WIIU_H
+
+#include "controller_api.h"
+
+extern struct ControllerAPI controller_wiiu;
+
+#endif

--- a/src/pc/pc_main.c
+++ b/src/pc/pc_main.c
@@ -163,21 +163,6 @@ void main_func(void) {
     main_pool_init(pool, pool + sizeof(pool) / sizeof(pool[0]));
     gEffectsMemoryPool = mem_pool_init(0x4000, MEMORY_POOL_LEFT);
 
-#ifdef TARGET_WII_U
-    WHBLogPrint("Main pool initialized.");
-
-    rendering_api = &gfx_whb_api;
-    wm_api = &gfx_sdl;
-    configFullscreen = true;
-
-    gfx_init(wm_api, rendering_api, "Super Mario 64 PC-Port", true);
-
-    WHBLogPrint("Gfx initialized.");
-
-    wm_api->set_fullscreen_changed_callback(NULL);
-    wm_api->set_keyboard_callbacks(NULL, NULL, NULL);
-
-#else
     configfile_load(CONFIG_FILE);
     atexit(save_config);
 
@@ -186,7 +171,12 @@ void main_func(void) {
     request_anim_frame(on_anim_frame);
 #endif
 
-#if defined(ENABLE_DX12)
+#if defined(TARGET_WII_U)
+    WHBLogPrint("Main pool initialized.");
+    rendering_api = &gfx_whb_api;
+    wm_api = &gfx_sdl;
+	configFullscreen = true;
+#elif defined(ENABLE_DX12)
     rendering_api = &gfx_direct3d12_api;
     wm_api = &gfx_dxgi_api;
 #elif defined(ENABLE_DX11)
@@ -206,7 +196,6 @@ void main_func(void) {
     wm_api->set_fullscreen_changed_callback(on_fullscreen_changed);
     wm_api->set_keyboard_callbacks(keyboard_on_key_down, keyboard_on_key_up, keyboard_on_all_keys_up);
 
-#endif
 
 #if HAVE_WASAPI
     if (audio_api == NULL && audio_wasapi.init()) {


### PR DESCRIPTION
This change replaces the SDL2-based input with the Wii U's native VPAD and KPAD APIs.

The Wii U GamePad, Wii Remote + Nunchuck, Classic Controller and Pro Controller are supported.